### PR TITLE
Undefined index notice fix

### DIFF
--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -259,14 +259,14 @@ class SQRLLogin {
             set_transient($nut, array(
                 'user'     => $user->id,
                 'ip'  => $this->getClientIP(),
-                'redir' => sanitize_text_field($_GET["redirect_to"]),
+                'redir' => isset( $_GET['redirect_to'] ) ? sanitize_text_field( $_GET['redirect_to'] ) : '',
                 'session'     => $session
             ), self::SESSION_TIMEOUT);
         } else {
             set_transient($nut, array(
                 'user'     => false,
                 'ip'  => $this->getClientIP(),
-                'redir' => sanitize_text_field($_GET["redirect_to"]),
+                'redir' => isset( $_GET['redirect_to'] ) ? sanitize_text_field( $_GET['redirect_to'] ) : '',
                 'session'     => $session
             ), self::SESSION_TIMEOUT);
         }


### PR DESCRIPTION
Issue #29 .

Description:
Fixes the notices of undefined variables.

Changes:
Checks if the $_GET['redirect_to'] is set else use default empty value.
